### PR TITLE
Feature: rename columns

### DIFF
--- a/ObservableTable/Core/History.cs
+++ b/ObservableTable/Core/History.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Text.Json;
 
 [assembly: InternalsVisibleTo("UnitTest")]
 namespace ObservableTable.Core;
@@ -17,6 +16,10 @@ internal interface IEdit
         if (this is RowEdit<T> row)
         {
             return new RowEdit<T>(row.Parity, row.IsInsert, row.Index, row);
+        }
+        if (this is ColumnRenameEdit<T> rename)
+        {
+            return new ColumnRenameEdit<T>(rename.Parity, rename.Index, rename.Header);
         }
         if (this is ColumnEdit<T> column)
         {
@@ -55,6 +58,23 @@ internal class ColumnEdit<T> : Column<T>, IEdit
     }
     internal ColumnEdit(int parity, bool isInsert, int index, Column<T> column) : this(parity, isInsert, index, column.Header, column.Values)
     { }
+}
+
+internal class ColumnRenameEdit<T> : IEdit
+{
+    public int Parity { get; init; }
+    public int Index { get; init; }
+    public T Header { get; set; }
+
+    // Unused members
+    public bool IsInsert { get; set; }
+
+    internal ColumnRenameEdit(int parity, int index, T header)
+    {
+        Parity = parity;
+        Index = index;
+        Header = header;
+    }
 }
 
 internal class CellEdit<T> : Cell<T>, IEdit

--- a/UnitTest/Core/Redo.cs
+++ b/UnitTest/Core/Redo.cs
@@ -104,6 +104,20 @@ public class Redo
     }
 
     [TestMethod]
+    public void Redo_RenameColumn_OperationsReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.RenameColumn(0, "D0");
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
     public void Redo_InsertColumns_OperationsReverted()
     {
         var expected = Helper.GetSampleTable();

--- a/UnitTest/Core/RenameColumn.cs
+++ b/UnitTest/Core/RenameColumn.cs
@@ -1,0 +1,55 @@
+using ObservableTable.Core;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class RenameColumn
+{
+    [TestMethod]
+    public void RenameColumn_NegativeIndex_Exception()
+    {
+        var actual = Helper.GetSampleTable();
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            actual.RenameColumn(-1, "New Header")
+        );
+    }
+
+    [TestMethod]
+    public void RenameColumn_ZeroIndex_RenamedHeader()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "D0", "B0", "C0" },
+            new string?[] { "A1", "B1", "C1" },
+            new string?[] { "A2", "B2", "C2" }
+        );
+
+        var actual = Helper.GetSampleTable();
+        actual.RenameColumn(0, "D0");
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void RenameColumn_LastIndex_RenamedHeader()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "D0" },
+            new string?[] { "A1", "B1", "C1" },
+            new string?[] { "A2", "B2", "C2" }
+        );
+
+        var actual = Helper.GetSampleTable();
+        actual.RenameColumn(actual.Headers.Count - 1, "D0");
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void RenameColumn_OverflowIndex_Exception()
+    {
+        var actual = Helper.GetSampleTable();
+        Assert.ThrowsException<ArgumentOutOfRangeException>(() =>
+            actual.RenameColumn(actual.Headers.Count, "D0")
+        );
+    }
+}

--- a/UnitTest/Core/Undo.cs
+++ b/UnitTest/Core/Undo.cs
@@ -84,6 +84,19 @@ public class Undo
     }
 
     [TestMethod]
+    public void Undo_RenameColumn_OperationReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.RenameColumn(0, "D0");
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
     public void Undo_RemoveRows_OperationsReverted()
     {
         var expected = Helper.GetSampleTable();


### PR DESCRIPTION
Currently supports one column at a time only to avoid awkward parameters.
Unit tests are modified to reflect the addition of the feature.