### PR TITLE
Bugfixes for TableModified

### DIFF
--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -162,12 +162,11 @@ public class ObservableTable<T>
 
     private void RecordTransaction(IEdit operation)
     {
+        TableModified?.Invoke(this, new());
+
         if (!recordTransactions) { return; }
         undo.Push(operation);
         redo.Clear();
-
-        if (TableModified is null) { return; }
-        TableModified(this, new());
     }
 
     internal IEdit UpdateCellEdit(IEdit edit)
@@ -196,10 +195,12 @@ public class ObservableTable<T>
         {
             case RowEdit<T> row when edit.IsInsert:
                 Records.Insert(row.Index, new(row));
+                TableModified?.Invoke(this, new());
                 break;
 
             case RowEdit<T> row:
                 Records.RemoveAt(row.Index);
+                TableModified?.Invoke(this, new());
                 break;
 
             case ColumnRenameEdit<T> column:

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -66,8 +66,9 @@ public class ObservableTable<T>
 
     private void RemoveRow(ObservableCollection<T?> row)
     {
-        RecordTransaction(new RowEdit<T>(parity, false, Records.IndexOf(row), row));
+        int index = Records.IndexOf(row);
         Records.Remove(row);
+        RecordTransaction(new RowEdit<T>(parity, false, index, row));
     }
 
     public void RenameColumn(int index, T header)

--- a/UnitTest/Core/EventHandler.cs
+++ b/UnitTest/Core/EventHandler.cs
@@ -6,7 +6,7 @@ namespace UnitTest.Core;
 public class EventHandler
 {
     [TestMethod]
-    public void EventHandler_Subscribed_Notified()
+    public void EventHandler_SetCell_Notified()
     {
         var table = Helper.GetSampleTable();
         var modified = false;
@@ -15,5 +15,93 @@ public class EventHandler
 
         table.SetCell(new Cell<string>(0, 0, "A1"));
         Assert.IsTrue(modified);
+    }
+
+
+    [TestMethod]
+    public void EventHandler_RenameColumn_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        var modified = false;
+
+        table.TableModified += (object? sender, EventArgs e) => modified = true;
+
+        table.RenameColumn(0, "H0");
+        Assert.IsTrue(modified);
+    }
+
+    [TestMethod]
+    public void EventHandler_InsertRow_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        var modified = false;
+
+        table.TableModified += (object? sender, EventArgs e) => modified = true;
+
+        table.InsertRow(0, new List<string?>());
+        Assert.IsTrue(modified);
+    }
+
+    [TestMethod]
+    public void EventHandler_RemoveRow_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        var modified = false;
+
+        table.TableModified += (object? sender, EventArgs e) => modified = true;
+
+        table.RemoveRow(table.Records[0]);
+        Assert.IsTrue(modified);
+    }
+
+    [TestMethod]
+    public void EventHandler_InsertColumn_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        var modified = false;
+
+        table.TableModified += (object? sender, EventArgs e) => modified = true;
+
+        table.InsertColumn(0, new Column<string>("A0"));
+        Assert.IsTrue(modified);
+    }
+
+    [TestMethod]
+    public void EventHandler_RemoveColumn_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        var modified = false;
+
+        table.TableModified += (object? sender, EventArgs e) => modified = true;
+
+        table.RemoveColumn("A0");
+        Assert.IsTrue(modified);
+    }
+
+    [TestMethod]
+    public void EventHandler_Undo_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        int modified = 0;
+
+        table.TableModified += (object? sender, EventArgs e) => modified++;
+
+        table.RenameColumn(0, "H0");
+        table.Undo();
+        Assert.IsTrue(modified == 2);
+    }
+
+    [TestMethod]
+    public void EventHandler_Redo_Notified()
+    {
+        var table = Helper.GetSampleTable();
+        int modified = 0;
+
+        table.TableModified += (object? sender, EventArgs e) => modified++;
+
+        table.RenameColumn(0, "H0");
+        table.Undo();
+        table.Redo();
+        Assert.IsTrue(modified == 3);
     }
 }


### PR DESCRIPTION
* [Incorrect row count when event triggers](https://github.com/haruki-taka8/ObservableTable/commit/e12fa8f2a223754d19c746bee0c86cd761984941)
* [TableModified not invoked when undoing/redoing](https://github.com/haruki-taka8/ObservableTable/commit/0c5bc702b8a99b97b35a929f275b65ed4222a9d1)