### PR TITLE
Improve PadRight<T> performance...

### DIFF
--- a/ObservableTable/Core/Extension.cs
+++ b/ObservableTable/Core/Extension.cs
@@ -9,7 +9,8 @@ internal static class Extension
             throw new ArgumentException("Input list longer than desired resultant length", nameof(list));
         }
 
-        var padding = Enumerable.Repeat<T?>(default, resultantLength - list.Count);
-        return list.Concat(padding).ToList();
+        var output = new T?[resultantLength];
+        list.CopyTo(output, 0);
+        return output;
     }
 }


### PR DESCRIPTION
...by converting PadRight<T> to use `IList.CopyTo()` instead of `Enumerable.Repeat()`

Mean runtime decreased by 79% according to internal benchmarks