### PR TITLE
Fix redoing reorders

### DIFF
--- a/ObservableTable/Core/History.cs
+++ b/ObservableTable/Core/History.cs
@@ -8,7 +8,7 @@ internal interface IEdit
     internal int Parity { get; init; }
 
     // Unused for CellEdit<T>
-    internal bool IsInsert { get; set; }
+    internal bool IsInverted { get; set; }
     internal int Index { get; init; }
 
     public IEdit DeepClone()
@@ -21,18 +21,18 @@ internal class RowEdit<T> : Row<T>, IEdit
 {
     public int Parity { get; init; }
     public int Index { get; init; }
-    public bool IsInsert { get; set; }
+    public bool IsInverted { get; set; }
 
     internal RowEdit(int parity, bool isInsert, int index, IList<T?> row) : base(row)
     {
         Parity = parity;
-        IsInsert = isInsert;
+        IsInverted = isInsert;
         Index = index;
     }
 
     IEdit IEdit.DeepClone()
     {
-        return new RowEdit<T>(Parity, IsInsert, Index, this);
+        return new RowEdit<T>(Parity, IsInverted, Index, this);
     }
 }
 
@@ -40,12 +40,12 @@ internal class ColumnEdit<T> : Column<T>, IEdit
 {
     public int Parity { get; init; }
     public int Index { get; init; }
-    public bool IsInsert { get; set; }
+    public bool IsInverted { get; set; }
 
     internal ColumnEdit(int parity, bool isInsert, int index, T header, IList<T?> values) : base(header, values)
     {
         Parity = parity;
-        IsInsert = isInsert;
+        IsInverted = isInsert;
         Index = index;
     }
     internal ColumnEdit(int parity, bool isInsert, int index, Column<T> column) : this(parity, isInsert, index, column.Header, column.Values)
@@ -53,7 +53,7 @@ internal class ColumnEdit<T> : Column<T>, IEdit
 
     IEdit IEdit.DeepClone()
     {
-        return new ColumnEdit<T>(Parity, IsInsert, Index, Header, Values);
+        return new ColumnEdit<T>(Parity, IsInverted, Index, Header, Values);
     }
 }
 
@@ -64,7 +64,7 @@ internal class ColumnRenameEdit<T> : IEdit
     public T Header { get; set; }
 
     // Unused members
-    public bool IsInsert { get; set; }
+    public bool IsInverted { get; set; }
 
     internal ColumnRenameEdit(int parity, int index, T header)
     {
@@ -85,7 +85,7 @@ internal class CellEdit<T> : Cell<T>, IEdit
 
     // Unused members
     public int Index { get; init; }
-    public bool IsInsert { get; set; }
+    public bool IsInverted { get; set; }
 
     internal CellEdit(int parity, int rowIndex, int columnIndex, T? value) : base(rowIndex, columnIndex, value)
     {
@@ -108,11 +108,10 @@ internal class ReorderEdit<T> : IEdit
     public int OldIndex { get; init; }
     public int NewIndex { get; init; }
     public bool IsColumn { get; init; }
-    public bool IsUndo { get; set; }
+    public bool IsInverted { get; set; }
 
     // Unused members
     public int Index { get; init; }
-    public bool IsInsert { get; set; }
 
     internal ReorderEdit(int parity, int oldIndex, int newIndex, bool isColumn)
     {

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -96,9 +96,7 @@ public class ObservableTable<T>
 
         foreach (var record in Records)
         {
-            T? item = record[oldIndex];
-            record.RemoveAt(oldIndex);
-            record.Insert(newIndex, item);
+            record.Move(oldIndex, newIndex);
         }
         RecordTransaction(new ReorderEdit<T>(parity, oldIndex, newIndex, true));
     }
@@ -251,13 +249,11 @@ public class ObservableTable<T>
         switch (edit)
         {
             case RowEdit<T> row when edit.IsInsert:
-                Records.Insert(row.Index, new(row));
-                TableModified?.Invoke(this, new());
+                InsertRow(row.Index, row);
                 break;
 
             case RowEdit<T> row:
-                Records.RemoveAt(row.Index);
-                TableModified?.Invoke(this, new());
+                RemoveRow(Records[row.Index]);
                 break;
 
             case ColumnRenameEdit<T> column:

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -234,12 +234,6 @@ public class ObservableTable<T>
             return cellEdit;
         }
 
-        if (edit is ReorderEdit<T> reorderEdit)
-        {
-            reorderEdit.IsUndo = !reorderEdit.IsUndo;
-            return reorderEdit;
-        }
-
         return edit;
     }
 

--- a/UnitTest/Core/Redo.cs
+++ b/UnitTest/Core/Redo.cs
@@ -76,6 +76,46 @@ public class Redo
     }
 
     [TestMethod]
+    public void Redo_ReorderColumn_OperationsReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReorderColumn(0, 1);
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void Redo_ReorderRow_OperationsReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReorderRow(0, 1);
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
     public void Redo_InsertRows_OperationsReverted()
     {
         var expected = Helper.GetSampleTable();
@@ -228,5 +268,26 @@ public class Redo
 
         actual.Redo();
         Assert.IsFalse(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void Redo_ReorderColumns_OperationReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReorderColumn(0, 1);
+        actual.ReorderColumn(0, 2);
+        actual.Undo();
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+
+        actual.Redo();
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
     }
 }

--- a/UnitTest/Core/Undo.cs
+++ b/UnitTest/Core/Undo.cs
@@ -213,4 +213,19 @@ public class Undo
         actual.Undo();
         Assert.IsTrue(expected.ContentEquals(actual));
     }
+
+    [TestMethod]
+    public void Undo_ReorderColumns_OperationReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReorderColumn(0, 1);
+        actual.ReorderColumn(1, 2);
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
 }


### PR DESCRIPTION
The following operations did not return a table to its original state:
```csharp
table.ReorderRow(0, 1);
table.ReorderRow(0, 2);
table.Undo();
table.Undo();
```
due to improper handling of the undo/redo state in `UpdateCellEdit(IEdit edit)`.

---

This PR
- fixes the above bug
- unifies `IsUndo` (from `ReorderEdit<T>`) and `IsInsert` (from `IEdit`) into `IsInverted` (in `IEdit`)
- includes additional unit tests covering this scenario