### PR TITLE
Optimization prefer structs

### DIFF
--- a/ObservableTable/Core/Container.cs
+++ b/ObservableTable/Core/Container.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.ObjectModel;
+﻿namespace ObservableTable.Core;
 
-namespace ObservableTable.Core;
-
-public class Column<T>
+public readonly struct Column<T>
 {
     public T Header { get; init; }
     public IList<T?> Values { get; init; }
@@ -12,6 +10,7 @@ public class Column<T>
         Header = header;
         Values = new List<T?>();
     }
+
     public Column(T header, IList<T?> values)
     {
         Header = header;
@@ -19,22 +18,16 @@ public class Column<T>
     }
 }
 
-public class Row<T> : Collection<T?>, IList<T?>
+public readonly struct Cell<T>
 {
-    public Row() : base() { }
-    public Row(IList<T?> values) : base(values) { }
-}
+    public int Row { get; init; }
+    public int Column { get; init; }
+    public T? Value { get; init; }
 
-public class Cell<T>
-{
-    public int RowIndex { get; init; }
-    public int ColumnIndex { get; init; }
-    public T? Value { get; set; }
-
-    public Cell(int rowIndex, int columnIndex, T? value)
+    public Cell(int row, int column, T? value)
     {
-        RowIndex = rowIndex;
-        ColumnIndex = columnIndex;
+        Row = row;
+        Column = column;
         Value = value;
     }
 }

--- a/ObservableTable/Core/History.cs
+++ b/ObservableTable/Core/History.cs
@@ -1,9 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿namespace ObservableTable.Core;
 
-[assembly: InternalsVisibleTo("UnitTest")]
-namespace ObservableTable.Core;
-
-internal class Edit
+internal readonly struct Edit
 {
     internal Action Undo { get; init; }
     internal Action Redo { get; init; }

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -1,8 +1,6 @@
 ﻿using System.Collections.ObjectModel;
 using System.Collections.Specialized;
-using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("UnitTest")]
 namespace ObservableTable.Core;
 
 public class ObservableTable<T>
@@ -215,7 +213,7 @@ public class ObservableTable<T>
     private void SetCell(Cell<T> cell)
     {
         // Let RecordChanged record the transcation
-        Records[cell.RowIndex][cell.ColumnIndex] = cell.Value;
+        Records[cell.Row][cell.Column] = cell.Value;
     }
 
     // Methods: History
@@ -264,8 +262,8 @@ public class ObservableTable<T>
             RevertHistory(last, isUndo);
 
             int offset = isUndo ? -1 : 1;
-            stack.TryPeek(out Edit? next);
-            if (last.Parity != next?.Parity + offset) { return; }
+            stack.TryPeek(out Edit next);
+            if (last.Parity != next.Parity + offset) { return; }
         }
     }
 


### PR DESCRIPTION
Internal benchmarks show that using structs instead of classes results in a 30% decrease in runtime for boxing and unboxing, and a 90% cut in runtime for initialization.

This PR converts `Column<T>`, `Cell<T>` and `Edit` into structs.

This PR also removes the `InternalsVisibleTo` attribute from `ObservableTable<T>` as it is no longer necessary.