### PR TITLE
Merge Stack.Any() and Stack.Pop() into stack.TryPop()

### DIFF
--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -212,7 +212,7 @@ public class ObservableTable<T>
 
     private void SetCell(Cell<T> cell)
     {
-        // Let RecordChanged record the transcation
+        // Let RecordChanged record the transaction
         Records[cell.Row][cell.Column] = cell.Value;
     }
 
@@ -255,13 +255,13 @@ public class ObservableTable<T>
 
     private void ProcessHistory(ref Stack<Edit> stack, ref Stack<Edit> opposite, bool isUndo)
     {
-        while (stack.Any())
+        int offset = isUndo ? -1 : 1;
+
+        while (stack.TryPop(out Edit last))
         {
-            Edit last = stack.Pop();
             opposite.Push(last);
             RevertHistory(last, isUndo);
 
-            int offset = isUndo ? -1 : 1;
             stack.TryPeek(out Edit next);
             if (last.Parity != next.Parity + offset) { return; }
         }


### PR DESCRIPTION
Performance-wise, internal benchmarks shows the PR provides **minimal** runtime decrease (~5%).

Metric-wise, the method's maintainability index increased from 66 to 68.
