### PR TITLE
ReplaceCell<T> and ReplaceCellSubstring

### DIFF
--- a/ObservableTable/Core/Extension.cs
+++ b/ObservableTable/Core/Extension.cs
@@ -2,7 +2,7 @@
 
 namespace ObservableTable.Core;
 
-internal static class Extension
+public static class Extension
 {
     private static IEnumerable<Cell<string>> ReplacedCells(string from, string to, bool matchRegex, IEnumerable<Cell<string>> cells)
     {

--- a/ObservableTable/Core/Helper.cs
+++ b/ObservableTable/Core/Helper.cs
@@ -1,0 +1,27 @@
+﻿namespace ObservableTable.Core;
+
+internal static class Helper
+{
+    internal static IList<T?> PadRight<T>(this IList<T?> list, int resultantLength)
+    {
+        if (list.Count > resultantLength)
+        {
+            throw new ArgumentException("Input list longer than desired resultant length", nameof(list));
+        }
+
+        var output = new T?[resultantLength];
+        list.CopyTo(output, 0);
+        return output;
+    }
+
+    internal static IEnumerable<Cell<T>> ListCells<T>(this ObservableTable<T> table)
+    {
+        for (int row = 0; row < table.Records.Count; row++)
+        {
+            for (int column = 0; column < table.Headers.Count; column++)
+            {
+                yield return new(row, column, table.Records[row][column]);
+            }
+        }
+    }
+}

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -216,6 +216,32 @@ public class ObservableTable<T>
         Records[cell.Row][cell.Column] = cell.Value;
     }
 
+    private static IEnumerable<Cell<T>> ReplacedCells(T from, T to, IEnumerable<Cell<T>> cells)
+    {
+        if (from is null) { yield break; }
+
+        foreach (var cell in cells)
+        {
+            if (!from.Equals(cell.Value)) { continue; }
+
+            Cell<T> newCell = new(cell.Row, cell.Column, to);
+            yield return newCell;
+        }
+    }
+
+    public void ReplaceCell(T from, T to, IEnumerable<Cell<T>>? cells = null)
+    {
+        cells ??= this.ListCells();
+
+        var toChange = ReplacedCells(from, to, cells).ToList();
+        SetCell(toChange);
+    }
+
+    public void ReplaceCell(T from, T to, params Cell<T>[] cells)
+    {
+        ReplaceCell(from, to, cells.ToList());
+    }
+
     // Methods: History
     internal void RecordChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {

--- a/UnitTest/Core/Helper.cs
+++ b/UnitTest/Core/Helper.cs
@@ -24,4 +24,13 @@ internal static class Helper
             new string?[] { "A5", "B5", "C5" }
         );
     }
+
+    internal static ObservableTable<int> GetSampleIntTable()
+    {
+        return new ObservableTable<int>(
+            new int[] { 1, 2, 3 },
+            new int[] { 4, 5, 6 },
+            new int[] { 7, 8, 9 }
+        );
+    }
 }

--- a/UnitTest/Core/Redo.cs
+++ b/UnitTest/Core/Redo.cs
@@ -345,4 +345,38 @@ public class Redo
         actual.Undo();
         Assert.IsTrue(expected.ContentEquals(actual));
     }
+
+    [TestMethod]
+    public void Undo_ReplaceCellSubstring_OperationsReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring(@"\d", "!", true);
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void Undo_ReplaceCell_OperationsReverted()
+    {
+        var expected = Helper.GetSampleIntTable();
+        var actual = Helper.GetSampleIntTable();
+
+        actual.ReplaceCell(4, 0);
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+        actual.Redo();
+        Assert.IsFalse(expected.ContentEquals(actual));
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
 }

--- a/UnitTest/Core/ReplaceCell.cs
+++ b/UnitTest/Core/ReplaceCell.cs
@@ -1,0 +1,71 @@
+﻿using ObservableTable.Core;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class ReplaceCell
+{
+    [TestMethod]
+    public void ReplaceCell_AllCells_Replaceable_Replaced()
+    {
+        ObservableTable<int> expected = new(
+            new int[] { 1, 2, 3 },
+            new int[] { 0, 5, 6 },
+            new int[] { 7, 8, 9 }
+        );
+        ObservableTable<int> actual = Helper.GetSampleIntTable();
+
+        actual.ReplaceCell(4, 0);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCell_AllCells_Irreplaceable_Nothing()
+    {
+        ObservableTable<int> expected = Helper.GetSampleIntTable();
+        ObservableTable<int> actual = Helper.GetSampleIntTable();
+
+        actual.ReplaceCell(2763, 0);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCell_FirstRow_Replaceable_Replaced()
+    {
+        ObservableTable<int> expected = new(
+           new int[] { 1, 2, 3 },
+           new int[] { 4, 0, 6 },
+           new int[] { 7, 8, 9 }
+        );
+        ObservableTable<int> actual = Helper.GetSampleIntTable();
+        List<Cell<int>> firstRow = new()
+        {
+            new(0, 0, 4),
+            new(0, 1, 5),
+            new(0, 2, 6)
+        };
+
+        actual.ReplaceCell(5, 0, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCell_FirstRow_Irreplaceable_Nothing()
+    {
+        ObservableTable<int> expected = Helper.GetSampleIntTable();
+        ObservableTable<int> actual = Helper.GetSampleIntTable();
+        List<Cell<int>> firstRow = new()
+        {
+            new(0, 0, 4),
+            new(0, 1, 5),
+            new(0, 2, 6)
+        };
+
+        actual.ReplaceCell(2763, 0, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+}

--- a/UnitTest/Core/ReplaceCellSubstring.cs
+++ b/UnitTest/Core/ReplaceCellSubstring.cs
@@ -1,0 +1,152 @@
+﻿using ObservableTable.Core;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class ReplaceCellSubstring
+{
+    [TestMethod]
+    public void ReplaceCellSubstring_NoRegex_AllCells_Replaceable_Replaced()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "C0" },
+            new string?[] { "!1", "B1", "C1" },
+            new string?[] { "!2", "B2", "C2" }
+        );
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring("A", "!");
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_NoRegex_AllCells_Irreplaceable_Nothing()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring("foobar", "!");
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_NoRegex_FirstRow_Replaceable_Replaced()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "C0" },
+            new string?[] { "A!", "B!", "C!" },
+            new string?[] { "A2", "B2", "C2" }
+        );
+        var actual = Helper.GetSampleTable();
+        List<Cell<string>> firstRow = new()
+        {
+            new(0, 0, "A1"),
+            new(0, 1, "B1"),
+            new(0, 2, "C1")
+        };
+
+        actual.ReplaceCellSubstring("1", "!", false, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_NoRegex_FirstRow_Irreplaceable_Nothing()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+        List<Cell<string>> firstRow = new()
+        {
+            new(0, 0, "A1"),
+            new(0, 1, "B1"),
+            new(0, 2, "C1")
+        };
+
+        actual.ReplaceCellSubstring("foobar", "!", false, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+
+    [TestMethod]
+    public void ReplaceCellSubstring_Regex_AllCells_Replaceable_Replaced()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "C0" },
+            new string?[] { "A!", "B!", "C!" },
+            new string?[] { "A!", "B!", "C!" }
+        );
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring(@"\d", "!", true);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_Regex_AllCells_Irreplaceable_Nothing()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring(@"\s", "!", true);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_Regex_FirstRow_Replaceable_Replaced()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "C0" },
+            new string?[] { "A!", "B!", "C!" },
+            new string?[] { "A2", "B2", "C2" }
+        );
+        var actual = Helper.GetSampleTable();
+        List<Cell<string>> firstRow = new()
+        {
+            new(0, 0, "A1"),
+            new(0, 1, "B1"),
+            new(0, 2, "C1")
+        };
+
+        actual.ReplaceCellSubstring(@"\d", "!", true, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_Regex_FirstRow_Irreplaceable_Nothing()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+        List<Cell<string>> firstRow = new()
+        {
+            new(0, 0, "A1"),
+            new(0, 1, "B1"),
+            new(0, 2, "C1")
+        };
+
+        actual.ReplaceCellSubstring(@"\s", "!", true, firstRow);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void ReplaceCellSubstring_Regex_AllCells_Replaceable_Grouped_Replaced()
+    {
+        ObservableTable<string> expected = new(
+            new string[] { "A0", "B0", "C0" },
+            new string?[] { "11", "11", "11" },
+            new string?[] { "22", "22", "22" }
+        );
+        var actual = Helper.GetSampleTable();
+
+
+        actual.ReplaceCellSubstring(@"^\w(\d)$", "$1$1", true);
+
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+}

--- a/UnitTest/Core/Undo.cs
+++ b/UnitTest/Core/Undo.cs
@@ -244,4 +244,30 @@ public class Undo
         actual.Undo();
         Assert.IsTrue(expected.ContentEquals(actual));
     }
+
+    [TestMethod]
+    public void Undo_ReplaceCellSubstring_OperationsReverted()
+    {
+        var expected = Helper.GetSampleTable();
+        var actual = Helper.GetSampleTable();
+
+        actual.ReplaceCellSubstring(@"\d", "!", true);
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
+
+    [TestMethod]
+    public void Undo_ReplaceCell_OperationsReverted()
+    {
+        var expected = Helper.GetSampleIntTable();
+        var actual = Helper.GetSampleIntTable();
+
+        actual.ReplaceCell(4, 0);
+        Assert.IsFalse(expected.ContentEquals(actual));
+
+        actual.Undo();
+        Assert.IsTrue(expected.ContentEquals(actual));
+    }
 }

--- a/UnitTest/Extension.cs
+++ b/UnitTest/Extension.cs
@@ -4,7 +4,7 @@ namespace UnitTest;
 
 internal static class Extension
 {
-    internal static bool ContentEquals(this ObservableTable<string> a, ObservableTable<string> b)
+    internal static bool ContentEquals<T>(this ObservableTable<T> a, ObservableTable<T> b)
     {
         // Headers
         if (!Enumerable.SequenceEqual(a.Headers, b.Headers))


### PR DESCRIPTION
`ReplaceCell<T>` allows consumers to find and replace particular values, either in the whole table, or in a selected cells by passing the `IEnumerable<Cell<T>> cells` argument.

`ReplaceCellSubstring` is an extension method designed for `ObservableTable<string>`, and can replace substrings matched in a string, either literally or through a regular expression. Selected cells-only replacement is also supported.