### PR TITLE
PadRight doesn't need its own exception

### DIFF
--- a/ObservableTable/Core/Helper.cs
+++ b/ObservableTable/Core/Helper.cs
@@ -4,11 +4,6 @@ internal static class Helper
 {
     internal static IList<T?> PadRight<T>(this IList<T?> list, int resultantLength)
     {
-        if (list.Count > resultantLength)
-        {
-            throw new ArgumentException("Input list longer than desired resultant length", nameof(list));
-        }
-
         var output = new T?[resultantLength];
         list.CopyTo(output, 0);
         return output;


### PR DESCRIPTION
CopyTo can throw one by itself when the source list is longer than the resultant one.