### PR TITLE
Contentful EventArgs

### DIFF
--- a/ObservableTable/Core/ModificationEventArgs.cs
+++ b/ObservableTable/Core/ModificationEventArgs.cs
@@ -1,0 +1,22 @@
+﻿namespace ObservableTable.Core;
+
+public class ModificationEventArgs : EventArgs
+{
+    public Action Action { get; init; }
+    public Action OppositeAction { get; init; }
+    public int Parity { get; init; }
+
+    public ModificationEventArgs(Action action, Action opposite, int parity)
+    {
+        Action = action;
+        OppositeAction = opposite;
+        Parity = parity;
+    }
+
+    internal ModificationEventArgs(Edit edit)
+    {
+        Action = edit.Redo;
+        OppositeAction = edit.Undo;
+        Parity = edit.Parity;
+    }
+}

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -10,7 +10,7 @@ public class ObservableTable<T>
     public ReadOnlyObservableCollection<T> Headers => new(headers);
     public int UndoCount => undo.Count;
     public int RedoCount => redo.Count;
-    public event EventHandler? TableModified;
+    public event EventHandler<ModificationEventArgs>? TableModified;
 
     private readonly ObservableCollection<T> headers = new();
     private Stack<Edit> undo = new();
@@ -229,10 +229,11 @@ public class ObservableTable<T>
 
     private void RecordTransaction(Action undoAction, Action redoAction)
     {
-        TableModified?.Invoke(this, new());
+        Edit edit = new(undoAction, redoAction, parity);
+        TableModified?.Invoke(this, new(edit));
 
         if (!recordTransactions) { return; }
-        undo.Push(new(undoAction, redoAction, parity));
+        undo.Push(edit);
         redo.Clear();
     }
 


### PR DESCRIPTION
This PR introduces `ModificationEventArgs`, used with the `TableModified` event. The class includes the following event data:

- Transaction (the completed `Action`)
- `Action` to reverse said transaction
- Parity of the transaction

This can be helpful in:

- overriding the built-in un/redo implementation
- invoking additional code on particular sets of edits (e.g. reconfiguring WPF bindings upon changing of columns)