### PR TITLE
Row/Column/CellIndexOf() Methods

### DIFF
--- a/ObservableTable/Core/Container.cs
+++ b/ObservableTable/Core/Container.cs
@@ -1,10 +1,13 @@
-﻿namespace ObservableTable.Core;
+﻿using System.Data.Common;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ObservableTable.Core;
 
 /// <summary>
 /// Describe a column of type <typeparamref name="T"/>.
 /// </summary>
 public readonly struct Column<T>
-{
+{ 
     public T Header { get; init; }
     public IList<T?> Values { get; init; }
 
@@ -24,6 +27,17 @@ public readonly struct Column<T>
     {
         Header = header;
         Values = values;
+    }
+
+    public bool Equals(Column<T> column)
+    {
+        return Equals(column.Header, column.Values);
+    }
+
+    public bool Equals(T header, IEnumerable<T?> values)
+    {
+        return Header!.Equals(header)
+            && Enumerable.SequenceEqual(Values, values);
     }
 }
 

--- a/ObservableTable/Core/Container.cs
+++ b/ObservableTable/Core/Container.cs
@@ -1,7 +1,4 @@
-﻿using System.Data.Common;
-using System.Diagnostics.CodeAnalysis;
-
-namespace ObservableTable.Core;
+﻿namespace ObservableTable.Core;
 
 /// <summary>
 /// Describe a column of type <typeparamref name="T"/>.
@@ -36,7 +33,8 @@ public readonly struct Column<T>
 
     public bool Equals(T header, IEnumerable<T?> values)
     {
-        return Header!.Equals(header)
+        return Header is not null
+            && Header.Equals(header)
             && Enumerable.SequenceEqual(Values, values);
     }
 }

--- a/UnitTest/Core/CellIndexOf.cs
+++ b/UnitTest/Core/CellIndexOf.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class CellIndexOf
+{
+    [TestMethod]
+    public void CellIndexOf_ExistentCell_Indices()
+    {
+        (int, int) expected = (1, 1);
+
+        var table = Helper.GetSampleTable();
+        (int, int) actual = table.CellIndexOf("B2");
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void CellIndexOf_ExistentCellAtTopLeft_Indices()
+    {
+        (int, int) expected = (0, 0);
+
+        var table = Helper.GetSampleTable();
+        (int, int) actual = table.CellIndexOf("A1");
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void CellIndexOf_ExistentCellAtBottomRight_Indices()
+    {
+        (int, int) expected = (1, 2);
+
+        var table = Helper.GetSampleTable();
+        (int, int) actual = table.CellIndexOf("C2");
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void CellIndexOf_NonexistentRow_NegativeOne()
+    {
+       (int, int) expected = (-1, -1);
+
+        var table = Helper.GetSampleTable();
+        (int, int) actual = table.CellIndexOf("foobar");
+
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/UnitTest/Core/ColumnIndexOf.cs
+++ b/UnitTest/Core/ColumnIndexOf.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class ColumnIndexOf
+{
+    [TestMethod]
+    public void ColumnIndexOf_ExistentColumn_Index()
+    {
+        int expected = 1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.ColumnIndexOf(new("B0", new List<string?>() { "B1", "B2" }));
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ColumnIndexOf_ExistentColumnAtZero_Index()
+    {
+        int expected = 0;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.ColumnIndexOf(new("A0", new List<string?>() { "A1", "A2" }));
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ColumnIndexOf_ExistentColumnAtCount_Index()
+    {
+        int expected = 2;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.ColumnIndexOf(new("C0", new List<string?>() { "C1", "C2" }));
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ColumnIndexOf_NonexistentColumn_NegativeOne()
+    {
+        int expected = -1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.ColumnIndexOf(new("foo", new List<string?>() { "bar", "baz" }));
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void ColumnIndexOf_ColumnLengthsMismatch_NegativeOne()
+    {
+        int expected = -1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.ColumnIndexOf(new("B0"));
+
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/UnitTest/Core/RowIndexOf.cs
+++ b/UnitTest/Core/RowIndexOf.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitTest.Core;
+
+[TestClass]
+public class RowIndexOf
+{
+    [TestMethod]
+    public void RowIndexOf_ExistentRow_Index()
+    {
+        int expected = 1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.RowIndexOf(table.Records[1]);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void RowIndexOf_ExistentRowAtZero_Index()
+    {
+        int expected = 0;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.RowIndexOf(table.Records[0]);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void RowIndexOf_NonexistentRow_NegativeOne()
+    {
+        int expected = -1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.RowIndexOf(new List<string?>() { "a", "b", "c" });
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    [TestMethod]
+    public void RowIndexOf_RowLengthsMismatch_NegativeOne()
+    {
+        int expected = -1;
+
+        var table = Helper.GetSampleTable();
+        int actual = table.RowIndexOf(new List<string?>());
+
+        Assert.AreEqual(expected, actual);
+    }
+}


### PR DESCRIPTION
Introducing `RowIndexOf()`, `ColumnIndexOf()` and `CellIndexOf()`.

These three methods return the first occurrence of their parameters in the table. They return -1 (column/row) or (-1, -1) (cell) if no matching containers are found.