### PR TITLE
Inline Replace Method

### DIFF
--- a/ObservableTable/Core/Helper.cs
+++ b/ObservableTable/Core/Helper.cs
@@ -32,31 +32,4 @@ internal static class Helper
             }
         }
     }
-
-    /// <summary>
-    /// Replace all occurrences of <paramref name="from"/> with <paramref name="to"/> in <paramref name="cells"/>.
-    /// </summary>
-    /// <returns>
-    /// The modified enumerable of <seealso cref="Cell{T}"/>.
-    /// </returns>
-    internal static IEnumerable<Cell<T>> Replace<T>(this IEnumerable<Cell<T>> cells, T from, T to)
-    {
-        foreach (var cell in cells)
-        {
-            yield return Replace(cell, from, to);
-        }
-    }
-
-    /// <summary>
-    /// Replace <paramref name="from"/> with <paramref name="to"/>.
-    /// </summary>
-    /// <returns>
-    /// The modified <seealso cref="Cell{T}"/>.
-    /// </returns>
-    private static Cell<T> Replace<T>(this Cell<T> cell, T from, T to)
-    {
-        return Equals(from, cell.Value)
-            ? new(cell.Row, cell.Column, to)
-            : cell;
-    }
 }

--- a/ObservableTable/Core/ObservableTable.cs
+++ b/ObservableTable/Core/ObservableTable.cs
@@ -262,11 +262,10 @@ public class ObservableTable<T>
     /// <param name="cells">Range of cell to perform the lookup. Skip to indicate whole table.</param>
     public void ReplaceCell(T from, T to, IEnumerable<Cell<T>>? cells = null)
     {
-        cells ??= this.ToCells();
-
-        cells = cells.Replace(from, to);
-
-        SetCell(cells);
+        cells = FindCell(from, cells);
+        
+        var newCells = cells.Select(x => new Cell<T>(x.Row, x.Column, to));
+        SetCell(newCells);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR removes two extension methods
```csharp
IEnumerable<Cell<T>> Replace<T>(this IEnumerable<Cell<T>> cells, T from, T to)
            Cell<T>  Replace<T>(this Cell<T> cell, T from, T to)
```
in favor of the `FindCell()` method already implemented in ObservableTable.

This PR will reduce code complexity and duplication. There might also be marginal performance improvements, especially when a large amount of Cell<T>'s are not to be replaced.